### PR TITLE
authchained's canDo doesn't return forwarded canDo result

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -75,7 +75,7 @@ class auth_plugin_authchained extends DokuWiki_Auth_Plugin {
 	     #echo "TEST AUTHMANAGER!!!";
 	     if($module[0] == 
 		$conf['plugin']['authchained']['usermanager_authtype']){
-		   $module[1]->canDo($cap);
+		   return $module[1]->canDo($cap);
 		}
 	  }
 	  return false;


### PR DESCRIPTION
I found that canDo capalities from authplain weren't properly handled. It is just a missing return when $this->chained_auth is null. Result from $module[1]->canDo($cap) isn't returned properly, losing it in the void.
